### PR TITLE
add feedback widget to docs site

### DIFF
--- a/material-overrides/assets/stylesheets/moonbeam.css
+++ b/material-overrides/assets/stylesheets/moonbeam.css
@@ -1011,3 +1011,22 @@ li>nav.md-nav[data-md-level="4"] {
     min-height: 77vh;
   }
 }
+
+/* Feedback widget styling */
+.md-feedback {
+  margin: 2em auto;
+  text-align: center;
+  border: 1px solid #53cbc9;
+  border-radius: 0.2em;
+  width: 30%;
+  padding: 0.7em;
+}
+
+.md-feedback__title {
+  font-family: 'Varela Round', sans-serif;
+  color: #353535;
+}
+
+.md-feedback__icon:not(:disabled).md-icon:hover {
+  color: #53cbc9;
+}

--- a/mkdocs-cn/mkdocs.yml
+++ b/mkdocs-cn/mkdocs.yml
@@ -258,3 +258,16 @@ docs_dir: moonbeam-docs-cn
   'analytics':
     'provider': 'google'
     'property': 'UA-135971059-6'
+    'feedback':
+        'title': '此页面是否有帮助?'
+        'ratings':
+            - 'icon': 'material/emoticon-happy-outline'
+              'name': '此页面很有帮助'
+              'data': 1
+              'note': >-
+                感谢您的反馈意见!
+            - 'icon': 'material/emoticon-sad-outline'
+              'name': '此页面有待改进'
+              'data': 0
+              'note': >- 
+                感谢您的反馈意见! 您还可以通过提交<a href="https://github.com/purestake/moonbeam-docs-cn/issues/new/?title=[Feedback]+{title}+-+{url}" target="_blank" rel="noopener">其他反馈</a>帮助我们改进此页面。

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -526,3 +526,17 @@
     'analytics':
         'provider': 'google'
         'property': 'UA-135971059-6'
+        'feedback':
+            'title': 'Was this page helpful?'
+            'ratings':
+                - 'icon': 'material/emoticon-happy-outline'
+                  'name': 'This page was helpful'
+                  'data': 1
+                  'note': >-
+                    Thanks for your feedback!
+                - 'icon': 'material/emoticon-sad-outline'
+                  'name': 'This page could be improved'
+                  'data': 0
+                  'note': >- 
+                    Thanks for your feedback! Help us improve this page by submitting
+                    <a href="https://github.com/purestake/moonbeam-docs/issues/new/?title=[Feedback]+{title}+-+{url}" target="_blank" rel="noopener">additional feedback</a>.


### PR DESCRIPTION
Adds the feedback widget to the docs site. The feedback (smiley or frown) can be viewed from the google analytics dashboard. If a user wants to provide additional feedback as to what can be improved, they are directed to create an issue on github.

Goes with EN PR: https://github.com/PureStake/moonbeam-docs/pull/570
Goes with CN PR: https://github.com/PureStake/moonbeam-docs-cn/pull/237

- [x] Still need to update `mkdocs-cn/mkdocs.yml` for CN site. Asked xinxin for help with this! 🙂 