### PR TITLE
update redirects from removing boba docs

### DIFF
--- a/mkdocs-cn/mkdocs.yml
+++ b/mkdocs-cn/mkdocs.yml
@@ -232,6 +232,9 @@ docs_dir: moonbeam-docs-cn
         'builders/xcm/xc-integration.md': 'builders/interoperability/xcm/xc-integration.md'
         'builders/xcm/xcm-transactor.md': 'builders/interoperability/xcm/xcm-transactor.md'
         'builders/xcm/remote-evm-calls.md': 'builders/interoperability/xcm/remote-evm-calls.md'
+        'builders/get-started/networks/layer2/index.md': 'builders/get-started/networks/index.md'
+        'builders/get-started/networks/layer2/bobabase.md': 'builders/get-started/networks/index.md'
+        'builders/get-started/networks/layer2/bobabeam.md': 'builders/get-started/networks/index.md'
   - 'macros':
       'include_yaml':
         - 'moonbeam-docs-cn/variables.yml'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -235,6 +235,9 @@
               'builders/xcm/xc-integration.md': 'builders/interoperability/xcm/xc-integration.md'
               'builders/xcm/xcm-transactor.md': 'builders/interoperability/xcm/xcm-transactor.md'
               'builders/xcm/remote-evm-calls.md': 'builders/interoperability/xcm/remote-evm-calls.md'
+              'builders/get-started/networks/layer2/index.md': 'builders/get-started/networks/index.md'
+              'builders/get-started/networks/layer2/bobabase.md': 'builders/get-started/networks/index.md'
+              'builders/get-started/networks/layer2/bobabeam.md': 'builders/get-started/networks/index.md'
               ### Deprecated Language Site Redirects ###
               'es/index.md': 'index.md'
               'es/resources/networks.md': 'learn/platform/networks/overview.md'


### PR DESCRIPTION
Add redirects for the removed boba pages back to the networks index page