### PR TITLE
Add document dates feature

### DIFF
--- a/material-overrides/assets/stylesheets/moonbeam.css
+++ b/material-overrides/assets/stylesheets/moonbeam.css
@@ -1030,3 +1030,20 @@ li>nav.md-nav[data-md-level="4"] {
 .md-feedback__icon:not(:disabled).md-icon:hover {
   color: #53cbc9;
 }
+
+/* Document date styling */
+.md-source-file {
+  display: flex;
+  justify-content: center;
+  margin-top: .5em;
+}
+.md-source-file small {
+  display: flex;
+  align-items: end;
+}
+.source-file-label {
+  margin-right: .5em;
+}
+.source-file-seperator {
+  margin: 0 .5em;
+}

--- a/material-overrides/assets/stylesheets/moonbeam.css
+++ b/material-overrides/assets/stylesheets/moonbeam.css
@@ -783,6 +783,10 @@ p.quick-ref-title {
   transform: scale(1.05);
 }
 
+.subsection-wrapper + .md-source-file {
+  margin-top: auto;
+}
+
 /* Section index page styles */
 .subsection-title {
   display: flex;
@@ -977,7 +981,7 @@ li>nav.md-nav[data-md-level="4"] {
 }
 
 /* Disclaimer styling */
-.md-content__inner.main-page {
+.md-content__inner {
   display: flex;
   flex-direction: column;
   min-height: 75vh;
@@ -995,19 +999,19 @@ li>nav.md-nav[data-md-level="4"] {
 }
 
 @media screen and (max-width: 719px) {
-  .md-content__inner.main-page {
+  .md-content__inner {
     min-height: 73vh;
   }
 }
 
 @media screen and (max-width: 1219px) and (min-width: 720px) {
-  .md-content__inner.main-page {
+  .md-content__inner {
     min-height: 81vh;
   }
 }
 
 @media screen and (max-width: 1599px) and (min-width: 1220px) {
-  .md-content__inner.main-page {
+  .md-content__inner {
     min-height: 77vh;
   }
 }

--- a/material-overrides/assets/stylesheets/moonbeam.css
+++ b/material-overrides/assets/stylesheets/moonbeam.css
@@ -585,6 +585,7 @@ p.md-footer-connect,
 .home {
   font-family: "Open Sans";
   margin: auto;
+  max-width: 100%;
 }
 
 .row {
@@ -1114,13 +1115,16 @@ li>nav.md-nav[data-md-level="4"] {
   justify-content: center;
   margin-top: .5em;
 }
+
 .md-source-file small {
   display: flex;
   align-items: end;
 }
+
 .source-file-label {
   margin-right: .5em;
 }
+
 .source-file-seperator {
   margin: 0 .5em;
 }

--- a/material-overrides/partials/source-file.html
+++ b/material-overrides/partials/source-file.html
@@ -1,0 +1,20 @@
+{#-
+    This file was automatically generated - do not edit
+  -#}
+  <div class="md-source-file">
+    <small>
+      {% if page.meta.git_revision_date_localized %}
+        <span class="source-file-label">{{ lang.t("source.file.date.updated") }}:</span>
+        {{ page.meta.git_revision_date_localized }}
+        {% if page.meta.git_creation_date_localized %}
+          <br>
+          <span class="source-file-seperator">|</span>
+          <span class="source-file-label">{{ lang.t("source.file.date.created") }}:</span>
+          {{ page.meta.git_creation_date_localized }}
+        {% endif %}
+      {% elif page.meta.revision_date %}
+        {{ lang.t("source.file.date.updated") }}:
+        {{ page.meta.revision_date }}
+      {% endif %}
+    </small>
+  </div>

--- a/mkdocs-cn/mkdocs.yml
+++ b/mkdocs-cn/mkdocs.yml
@@ -45,6 +45,8 @@ docs_dir: moonbeam-docs-cn
 'plugins':
   - 'search'
   - 'awesome-pages'
+  - 'git-revision-date-localized':
+      'enable_creation_date': !!bool 'true'
   - 'redirects':
       'redirect_maps':
         'resources/networks.md': 'learn/platform/networks/overview.md'

--- a/mkdocs-cn/mkdocs.yml
+++ b/mkdocs-cn/mkdocs.yml
@@ -10,6 +10,7 @@ docs_dir: moonbeam-docs-cn
   - 'js/networkModal.js'
   - 'js/handleLanguageChange.js'
   - 'js/renderSubsections.js'
+  - 'js/fixCreatedDate.js'
 'theme':
   'name': 'material'
   'custom_dir': 'material-overrides'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,7 @@
     - 'awesome-pages'
     - 'git-revision-date-localized':
         'enable_creation_date': !!bool 'true'
+        'enabled': !ENV [CI, false]
     - 'redirects':
           'redirect_maps':
               'resources/networks.md': 'learn/platform/networks/overview.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,7 +47,6 @@
     - 'awesome-pages'
     - 'git-revision-date-localized':
         'enable_creation_date': !!bool 'true'
-        'enabled': !ENV [CI, false]
     - 'redirects':
           'redirect_maps':
               'resources/networks.md': 'learn/platform/networks/overview.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,7 @@
     - 'js/networkModal.js'
     - 'js/handleLanguageChange.js'
     - 'js/renderSubsections.js'
+    - 'js/fixCreatedDate.js'
 'theme':
     'name': 'material'
     'custom_dir': 'material-overrides'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,6 +45,8 @@
 'plugins':
     - 'search'
     - 'awesome-pages'
+    - 'git-revision-date-localized':
+        'enable_creation_date': !!bool 'true'
     - 'redirects':
           'redirect_maps':
               'resources/networks.md': 'learn/platform/networks/overview.md'

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ Markdown==3.3.7
 MarkupSafe==2.1.2 
 mkdocs==1.4.2
 mkdocs-awesome-pages-plugin==2.8.0
+mkdocs-git-revision-date-localized-plugin==1.2.0
 mkdocs-macros-plugin==0.7.0
 mkdocs-macros-test==0.1.0 
 mkdocs-material==9.0.8


### PR DESCRIPTION
Add a feature that puts the last updated and created dates on each page. Tried to remove on the section index pages, but there is no easy way to do so. I don't think it looks terrible but not entirely necessary 🤷‍♀️ 

There is an issue with a handful of pages where the plugin cannot find the date a page was created and it automatically defaults to the current date. So, I created a script that checks the dates on each page and if the created date is after the updated date, it renders the updated date as the created date instead.

Goes with: https://github.com/PureStake/moonbeam-docs/pull/597