### PR TITLE
add additional home page break points and fix width of the external link pop-up

### DIFF
--- a/material-overrides/assets/stylesheets/moonbeam.css
+++ b/material-overrides/assets/stylesheets/moonbeam.css
@@ -947,8 +947,11 @@ p.quick-ref-title {
     width: 90%;
     margin: auto;
   }
-}
 
+  .row.quick-refs-medium .quick-ref-title {
+    margin-top: 1.3em;
+  }
+}
 
 @media screen and (max-width: 57.325em) {
   .hero-img {

--- a/material-overrides/assets/stylesheets/moonbeam.css
+++ b/material-overrides/assets/stylesheets/moonbeam.css
@@ -351,24 +351,29 @@ a:hover {
   font-size: .8em;
 }
 
+@media screen and (max-width: 76.1875em) {
+  .error-modal-container,
+  .network-modal-container {
+    width: 50%;
+  }
+
+  .external-link-modal-container {
+    width: 60%;
+  }
+}
+
 @media screen and (max-width: 46.1875em) {
-  .external-link-modal-container,
   .error-modal-container,
   .network-modal-container {
     width: 80%;
   }
-  .external-link-modal,
   .error-modal,
   .network-modal {
     margin: 25% auto;
   }
-}
 
-@media screen and (max-width: 76.1875em) {
-  .external-link-modal-container,
-  .error-modal-container,
-  .network-modal-container {
-    width: 50%;
+  .external-link-modal-container {
+    width: 90%;
   }
 }
 
@@ -611,6 +616,10 @@ p.md-footer-connect,
   margin-right: 3em;
   margin-left: 0;
   width: 100%;
+}
+
+.row.quick-refs-medium, .row.hero-buttons-small {
+  display: none;
 }
 
 h1.hero-title {
@@ -876,7 +885,7 @@ p.quick-ref-title {
 
   .card {
     width: unset;
-    flex: 40%
+    flex: 40%;
   }
 
   .card>div:first-child,
@@ -906,6 +915,46 @@ p.quick-ref-title {
   h1.hero-title {
     margin-top: 0;
   }
+
+  .row.quick-refs {
+    display: none;
+  }
+
+  .row.quick-refs-medium {
+    display: block;
+    width: 90%;
+    margin: auto;
+  }
+
+  .row.quick-refs-medium .quick-ref-title {
+    margin-top: 0;
+  }
+
+}
+
+@media screen and (max-width: 62em) {
+  .hero-img {
+    padding: 0;
+    width: 60em;
+  }
+
+  .hero-info ~ .row.hero-buttons {
+    display: none;
+  }
+
+  .row.hero ~ .row.hero-buttons-small {
+    display: block;
+    width: 90%;
+    margin: auto;
+  }
+}
+
+
+@media screen and (max-width: 57.325em) {
+  .hero-img {
+    padding: 0;
+    width: 60em;
+  }
 }
 
 @media screen and (max-width: 48.125em) {
@@ -920,7 +969,7 @@ p.quick-ref-title {
   .card {
     width: unset;
     margin: .5em 0;
-    flex: 100%
+    flex: 100%;
   }
 
   .hero-column {

--- a/material-overrides/home.html
+++ b/material-overrides/home.html
@@ -16,7 +16,6 @@
         <br><br>
         Dive into the tools, integrations, and comprehensive tutorials to start using and building on Moonbeam.
       </h3>
-
       <div class="row hero-buttons">
         <a href="/builders/get-started/">
           <button class="pink-primary-button md-button">Start Building <span class="md-icon">{% include
@@ -54,6 +53,42 @@
     </div>
     <div class="column">
       <img class="hero-img" src="{{ '/assets/images/hero.png' }}" alt="representation of the Moonbeam docs site" />
+    </div>
+  </div>
+  <div class="row hero-buttons-small">
+    <div class="row hero-buttons">
+      <a href="/builders/get-started/">
+        <button class="pink-primary-button md-button">Start Building <span class="md-icon">{% include
+            ".icons/material/arrow-right.svg" %}</span></button>
+      </a>
+      <a href="https://immunefi.com/bounty/moonbeamnetwork/">
+        <button class="pink-secondary-button md-button">Bug Bounty <span class="md-icon">{% include
+            ".icons/material/arrow-right.svg" %}</span></button>
+      </a>
+      <a href="https://moonbeam.foundation/grants/">
+        <button class="pink-secondary-button md-button">Grants Program <span class="md-icon">{% include
+            ".icons/material/arrow-right.svg" %}</span></button>
+      </a>
+    </div>
+  </div>
+  <div class="row quick-refs-medium">
+    <p class="quick-ref-title">Quick References</p>
+    <div class="quick-ref-buttons">
+      <a href="/builders/get-started/eth-compare/">
+        <button class="md-button quick-ref-button">Moonbeam vs Ethereum</button>
+      </a>
+      <a href="/builders/build/canonical-contracts/">
+        <button class="md-button quick-ref-button">Canonical Contracts</button>
+      </a>
+      <a href="/builders/get-started/endpoints/">
+        <button class="md-button quick-ref-button">Network Endpoints</button>
+      </a>
+      <a href="/builders/get-started/eth-compare/security">
+        <button class="md-button quick-ref-button">Security Considerations</button>
+      </a>
+      <a href="/builders/build/historical-updates">
+        <button class="md-button quick-ref-button">Historical Updates</button>
+      </a>
     </div>
   </div>
   <div class="row cards">

--- a/mkdocs-cn/material-overrides/home.html
+++ b/mkdocs-cn/material-overrides/home.html
@@ -54,6 +54,42 @@
       <img class="hero-img" src="{{ '/assets/images/hero.png' }}" alt="representation of the Moonbeam docs site" />
     </div>
   </div>
+  <div class="row hero-buttons-small">
+    <div class="row hero-buttons">
+      <a href="/builders/get-started/">
+        <button class="pink-primary-button md-button">开始构建节点<span class="md-icon">{% include
+            ".icons/material/arrow-right.svg" %}</span></button>
+      </a>
+      <a href="https://immunefi.com/bounty/moonbeamnetwork/">
+        <button class="pink-secondary-button md-button">Bug Bounty赏金计划<span class="md-icon">{% include
+            ".icons/material/arrow-right.svg" %}</span></button>
+      </a>
+      <a href="https://moonbeam.foundation/zh/grants/">
+        <button class="pink-secondary-button md-button">Grants加速计划<span class="md-icon">{% include
+            ".icons/material/arrow-right.svg" %}</span></button>
+      </a>
+    </div>   
+  </div>
+  <div class="row quick-refs-medium">
+    <p class="quick-ref-title">快速参考</p>
+    <div class="quick-ref-buttons">
+      <a href="/builders/get-started/eth-compare/">
+        <button class="md-button quick-ref-button">Moonbeam vs 以太坊</button>
+      </a>
+      <a href="/builders/build/canonical-contracts/">
+        <button class="md-button quick-ref-button">标准合约</button>
+      </a>
+      <a href="/builders/get-started/endpoints/">
+        <button class="md-button quick-ref-button">API供应者</button>
+      </a>
+      <a href="/builders/get-started/eth-compare/security">
+        <button class="md-button quick-ref-button">安全注意事项</button>
+      </a>
+      <a href="/builders/build/historical-updates">
+        <button class="md-button quick-ref-button">历史更新</button>
+      </a>
+    </div>
+  </div>  
   <div class="row cards">
     <div class="card">
       <div>


### PR DESCRIPTION
Add some additional breakpoints so that the home page looks better on various size screens. Had to do some trickery to make this possible because the HTML elements are initially in columns, so I had to move some elements out of the column format at certain points, hence why the `row hero-buttons-small` and `row quick-refs-medium` divs are required

This also fixes the external links modal to look good on all screens.