### PR TITLE
Fix navigation

### DIFF
--- a/material-overrides/assets/stylesheets/moonbeam.css
+++ b/material-overrides/assets/stylesheets/moonbeam.css
@@ -41,10 +41,6 @@ h4 {
 }
 
 /* General styling adjustments */
-body {
-  min-width: fit-content;
-}
-
 [data-md-toggle='search']:checked~.md-header .md-search__input {
   color: #000000;
 }
@@ -991,8 +987,17 @@ p.quick-ref-title {
 }
 
 @media screen and (max-width: 30em) {
-  .md-header-nav__ellipsis.md-ellipsis {
-    display: none;
+  nav .md-header__title[data-md-component=header-title] {
+    margin-left: 0;
+  }
+
+  .md-header__title {
+    position: relative;
+  }
+
+  .md-header__ellipsis.md-ellipsis {
+    display: flex;
+    position: absolute;
   }
 }
 

--- a/material-overrides/assets/stylesheets/moonbeam.css
+++ b/material-overrides/assets/stylesheets/moonbeam.css
@@ -1154,6 +1154,7 @@ li>nav.md-nav[data-md-level="4"] {
 
   .md-source-file small {
     display: block;
+    text-align: center;
   }
   
   .disclaimer {


### PR DESCRIPTION
I noticed on Friday that content pages weren't rendering correctly but the home page and index pages were rendered perfectly fine. So `fit-content` won't work as a general fix. So I dug a bit deeper and realized that the `.md-header-nav__*` classes were removed and replaced with `.md-header__*` classes at some point and this wasn't caught when I updated the dependencies. So this was causing issues with the top navigation where the width of the nav was smaller than the width of all of the elements combined for small screens (not all mobile devices, but some). Which caused the screen to widen and a horizontal scrollbar to appear and the  language dropdown to hang off the edge.

Previously, the solution was to get rid of the title on the home page, but I noticed that on all of the index pages and content pages the title was there it was just shortened. So I applied this same logic manually to the home page. 