### PR TITLE
Add templates for index pages

### DIFF
--- a/material-overrides/assets/stylesheets/moonbeam.css
+++ b/material-overrides/assets/stylesheets/moonbeam.css
@@ -620,7 +620,7 @@ p.md-footer-connect,
 h1.hero-title {
   font-weight: 400;
   font-size: 1.75em;
-  margin-top: 1em;
+  margin-top: .5em;
 }
 
 h3.hero-info {

--- a/material-overrides/assets/stylesheets/moonbeam.css
+++ b/material-overrides/assets/stylesheets/moonbeam.css
@@ -1072,16 +1072,17 @@ li>nav.md-nav[data-md-level="4"] {
 
 /* Disclaimer styling */
 .md-content__inner .main-page {
-  display: flex;
-  flex-direction: column;
-  min-height: 73vh;
+  min-height: 75vh;
   margin-bottom: .5rem;
+  position: relative;
 }
 
 .disclaimer, .page-disclaimer {
   margin-top: auto;
   font-size: x-small;
   font-style: italic;
+  position: absolute;
+  bottom: 0;
 }
 
 .page-disclaimer {
@@ -1091,18 +1092,21 @@ li>nav.md-nav[data-md-level="4"] {
 @media screen and (max-width: 719px) {
   .md-content__inner .main-page {
     min-height: 71vh;
+    position: relative;
   }
 }
 
 @media screen and (max-width: 1219px) and (min-width: 720px) {
   .md-content__inner .main-page {
     min-height: 79vh;
+    position: relative;
   }
 }
 
 @media screen and (max-width: 1599px) and (min-width: 1220px) {
   .md-content__inner .main-page {
     min-height: 73vh;
+    position: relative;
   }
 }
 

--- a/material-overrides/assets/stylesheets/moonbeam.css
+++ b/material-overrides/assets/stylesheets/moonbeam.css
@@ -1071,10 +1071,10 @@ li>nav.md-nav[data-md-level="4"] {
 }
 
 /* Disclaimer styling */
-.md-content__inner {
+.md-content__inner .main-page {
   display: flex;
   flex-direction: column;
-  min-height: 75vh;
+  min-height: 73vh;
   margin-bottom: .5rem;
 }
 
@@ -1089,20 +1089,20 @@ li>nav.md-nav[data-md-level="4"] {
 }
 
 @media screen and (max-width: 719px) {
-  .md-content__inner {
-    min-height: 73vh;
+  .md-content__inner .main-page {
+    min-height: 71vh;
   }
 }
 
 @media screen and (max-width: 1219px) and (min-width: 720px) {
-  .md-content__inner {
-    min-height: 81vh;
+  .md-content__inner .main-page {
+    min-height: 79vh;
   }
 }
 
 @media screen and (max-width: 1599px) and (min-width: 1220px) {
-  .md-content__inner {
-    min-height: 77vh;
+  .md-content__inner .main-page {
+    min-height: 73vh;
   }
 }
 

--- a/material-overrides/assets/stylesheets/moonbeam.css
+++ b/material-overrides/assets/stylesheets/moonbeam.css
@@ -1072,17 +1072,16 @@ li>nav.md-nav[data-md-level="4"] {
 
 /* Disclaimer styling */
 .md-content__inner .main-page {
+  display: flex;
+  flex-direction: column;
   min-height: 75vh;
   margin-bottom: .5rem;
-  position: relative;
 }
 
 .disclaimer, .page-disclaimer {
   margin-top: auto;
   font-size: x-small;
   font-style: italic;
-  position: absolute;
-  bottom: 0;
 }
 
 .page-disclaimer {
@@ -1092,21 +1091,18 @@ li>nav.md-nav[data-md-level="4"] {
 @media screen and (max-width: 719px) {
   .md-content__inner .main-page {
     min-height: 71vh;
-    position: relative;
   }
 }
 
 @media screen and (max-width: 1219px) and (min-width: 720px) {
   .md-content__inner .main-page {
     min-height: 79vh;
-    position: relative;
   }
 }
 
 @media screen and (max-width: 1599px) and (min-width: 1220px) {
   .md-content__inner .main-page {
     min-height: 73vh;
-    position: relative;
   }
 }
 

--- a/material-overrides/main-index-page.html
+++ b/material-overrides/main-index-page.html
@@ -1,0 +1,42 @@
+{% extends "main.html" %}
+
+{% block content %}
+<div class="main-page">
+    {% if nav|length>1 %}
+    {% for nav_item in nav %}
+    {% if nav_item.is_section and nav_item.active %}
+    <h1 class="subsection-title">{{ nav_item.title }}</h1>
+    <div class="subsection-wrapper">
+        {% for nav_item in nav_item.children %}
+        {% if nav_item.is_section %}
+        <div class="card">
+            {% set subsection_path = nav_item.children[0].url %}
+            {% if subsection_path.startswith(page.url) %}
+            {% set image_path = '/images/index-pages/' + subsection_path[:-1] + '.png' %}
+            {% set href_path = subsection_path|replace(page.url, '') %}
+            <a href="{{ href_path }}">
+                <h2 class="title">{{ nav_item.title }}</h2>
+                <img class="icon" src="{{ image_path }}"
+                    onerror="this.src=/images/index-pages/blank.png; this.onerror = null">
+            </a>
+            {% endif %}
+        </div>
+        {% endif %}
+        {% endfor %}
+    </div>
+    {% endif %}
+    {% endfor %}
+    {% endif %}
+    <div class="disclaimer">All information made available, including claims, content, designs, algorithms, estimates,
+        roadmaps, specifications, and performance measurements described in this project are provided for informational
+        purposes only and Moonbeam does not endorse any project referenced here. It is up to the reader to check and
+        validate the accuracy and truthfulness. Furthermore, nothing in this project information constitutes a
+        solicitation for investment. No developer or entity involved in creating the Moonbeam Network or Moonriver
+        Network or authoring this information will be liable for any claims or damages whatsoever associated with your
+        use, inability to use, or your interaction with other users of, the Moonbeam Network or Moonriver Network or any
+        information made available on this website, including any direct, indirect, incidental, special, exemplary,
+        punitive or consequential damages, or loss of profits, cryptocurrencies, tokens, or anything else of value. All
+        information contained herein is subject to modification without notice.</div>
+</div>
+
+{% endblock %}

--- a/material-overrides/subsection-index-page.html
+++ b/material-overrides/subsection-index-page.html
@@ -3,7 +3,6 @@
 {% block content %}
 
 {% macro find_active_page(element) %}
-
   {% for nav_item in element %}
     {% if nav_item.active %}
       {% if nav_item.is_section %}
@@ -54,9 +53,7 @@
   {% endif %}
 
   {% if element.active and element.children %}
-    Hei
     {% for child in element.children %}
-      Here
       {% set nested_active_element = find_active_page(child) %}
       {% if nested_active_element != none %}
         {% set most_nested_active_element = nested_active_element %}

--- a/material-overrides/subsection-index-page.html
+++ b/material-overrides/subsection-index-page.html
@@ -23,16 +23,15 @@
             <!-- for pages that point to sections within other pages -->
             {% if '#' in subsection_path %} 
               <!-- remove the section from the path -->
-              {% set subsection_path = subsection_path.split('#')[0][1:] %}
+              {% set subsection_path = subsection_path.split('#')[0] %}
             {% endif %}
-            <!-- for pages that point to other directories -->
-            {% if page.url not in subsection_path %}
+            {% if subsection_path.startswith('/') %}
               <!-- remove initial '/' from relative path -->
               {% set subsection_path = subsection_path[1:] %}
-              {% if not subsection_path.endswith('/') %}
-                <!-- add '/' to end of path to match all of the other urls -->
-                {% set subsection_path = subsection_path + '/' %}
-              {% endif %}
+            {% endif %}
+            {% if not subsection_path.endswith('/') %}
+              <!-- add '/' to end of path to match all of the other urls -->
+              {% set subsection_path = subsection_path + '/' %}
             {% endif %}
             {% set image_path = '/images/index-pages/' + subsection_path[:-1] + '.png' %}
             <div class="card">

--- a/material-overrides/subsection-index-page.html
+++ b/material-overrides/subsection-index-page.html
@@ -20,6 +20,20 @@
             {% else %}
               {% set subsection_path = nav_item.url %}
             {% endif %}
+            <!-- for pages that point to sections within other pages -->
+            {% if '#' in subsection_path %} 
+              <!-- remove the section from the path -->
+              {% set subsection_path = subsection_path.split('#')[0][1:] %}
+            {% endif %}
+            <!-- for pages that point to other directories -->
+            {% if page.url not in subsection_path %}
+              <!-- remove initial '/' from relative path -->
+              {% set subsection_path = subsection_path[1:] %}
+              {% if not subsection_path.endswith('/') %}
+                <!-- add '/' to end of path to match all of the other urls -->
+                {% set subsection_path = subsection_path + '/' %}
+              {% endif %}
+            {% endif %}
             {% set image_path = '/images/index-pages/' + subsection_path[:-1] + '.png' %}
             <div class="card">
               <a href="{{ subsection_path|replace(page.url, '') }}">

--- a/material-overrides/subsection-index-page.html
+++ b/material-overrides/subsection-index-page.html
@@ -1,0 +1,64 @@
+{% extends "main.html" %}
+
+{% block content %}
+
+{% macro find_active_page(element) %}
+
+  {% for nav_item in element %}
+    {% if nav_item.active %}
+      {% if nav_item.is_section %}
+        <!-- continue to find active page -->
+        {{ find_active_page(nav_item.children) }}
+      {% else %}
+        <!-- render subsection content -->
+        {% if nav_item.is_page %}
+          <h1 class="subsection-title">{{ nav_item.parent.title }}</h1>
+          <div class="subsection-wrapper">
+          {% for nav_item in element[1:] %}
+            {% if nav_item.is_section %}
+              {% set subsection_path = nav_item.children[0].url %}
+            {% else %}
+              {% set subsection_path = nav_item.url %}
+            {% endif %}
+            {% set image_path = '/images/index-pages/' + subsection_path[:-1] + '.png' %}
+            <div class="card">
+              <a href="{{ subsection_path|replace(page.url, '') }}">
+                <h2 class="title">{{ nav_item.title }}</h2> 
+                <img class="icon" src="{{ image_path }}">
+              </a>    
+            </div>
+          {% endfor %}
+          </div>
+        {% endif %}
+      {% endif %}
+    {% endif %}
+  {% endfor %}
+
+  {% set most_nested_active_element = None %}
+  {% if element.active == True %}
+    {{ element }}
+    {% set most_nested_active_element = element %}
+  {% endif %}
+
+  {% if element.active and element.children %}
+    Hei
+    {% for child in element.children %}
+      Here
+      {% set nested_active_element = find_active_page(child) %}
+      {% if nested_active_element != none %}
+        {% set most_nested_active_element = nested_active_element %}
+      {% endif %}
+    {% endfor %}
+  {% endif %}
+{% endmacro %}
+
+<div class="subsection-page">
+    {% if nav|length>1 %}
+      {% for nav_item in nav %}
+        {% if nav_item.is_section and nav_item.active %}
+          {{ find_active_page(nav_item.children) }}
+        {% endif %}
+      {% endfor %}
+    {% endif %}
+</div>
+{% endblock %}

--- a/mkdocs-cn/material-overrides/main-index-page.html
+++ b/mkdocs-cn/material-overrides/main-index-page.html
@@ -1,0 +1,37 @@
+{% extends "main.html" %}
+
+{% block content %}
+<div class="main-page">
+    {% if nav|length>1 %}
+    {% for nav_item in nav %}
+    {% if nav_item.is_section and nav_item.active %}
+    <h1 class="subsection-title">{{ nav_item.title }}</h1>
+    <div class="subsection-wrapper">
+        {% for nav_item in nav_item.children %}
+        {% if nav_item.is_section %}
+        <div class="card">
+            {% set subsection_path = nav_item.children[0].url %}
+            {% if subsection_path.startswith(page.url) %}
+            {% set image_path = '/images/index-pages/' + subsection_path[:-1] + '.png' %}
+            {% set href_path = subsection_path|replace(page.url, '') %}
+            <a href="{{ href_path }}">
+                <h2 class="title">{{ nav_item.title }}</h2>
+                <img class="icon" src="{{ image_path }}"
+                    onerror="this.src=/images/index-pages/blank.png; this.onerror = null">
+            </a>
+            {% endif %}
+        </div>
+        {% endif %}
+        {% endfor %}
+    </div>
+    {% endif %}
+    {% endfor %}
+    {% endif %}
+    <div class="disclaimer">
+        本项目所提供的所有信息，包括声明、内容、设计、算法、估计、路线图、规格和性能测量，仅供参考之用，与Moonbeam立场无关，概不构成任何投资建议，请自行研究和判断其准确性和真实性。任何参与创建Moonbeam
+        Network或Moonriver Network或撰写所有信息的开发人员或实体均不承担任何用户或人士就使用或未能使用或与Moonbeam Network或Moonriver
+        Network其他用户交互的本网站所提供的任何信息，包括任何直接、间接、附带、从属、特殊、惩戒性、惩罚性或后果性的损害赔偿，或利润、加密货币、Token或任何其他有价值的东西的损失。此处包含的信息如有变更，恕不另行通知。
+    </div>
+</div>
+
+{% endblock %}

--- a/mkdocs-cn/material-overrides/subsection-index-page.html
+++ b/mkdocs-cn/material-overrides/subsection-index-page.html
@@ -3,7 +3,6 @@
 {% block content %}
 
 {% macro find_active_page(element) %}
-
   {% for nav_item in element %}
     {% if nav_item.active %}
       {% if nav_item.is_section %}
@@ -54,9 +53,7 @@
   {% endif %}
 
   {% if element.active and element.children %}
-    Hei
     {% for child in element.children %}
-      Here
       {% set nested_active_element = find_active_page(child) %}
       {% if nested_active_element != none %}
         {% set most_nested_active_element = nested_active_element %}

--- a/mkdocs-cn/material-overrides/subsection-index-page.html
+++ b/mkdocs-cn/material-overrides/subsection-index-page.html
@@ -23,16 +23,15 @@
             <!-- for pages that point to sections within other pages -->
             {% if '#' in subsection_path %} 
               <!-- remove the section from the path -->
-              {% set subsection_path = subsection_path.split('#')[0][1:] %}
+              {% set subsection_path = subsection_path.split('#')[0] %}
             {% endif %}
-            <!-- for pages that point to other directories -->
-            {% if page.url not in subsection_path %}
+            {% if subsection_path.startswith('/') %}
               <!-- remove initial '/' from relative path -->
               {% set subsection_path = subsection_path[1:] %}
-              {% if not subsection_path.endswith('/') %}
-                <!-- add '/' to end of path to match all of the other urls -->
-                {% set subsection_path = subsection_path + '/' %}
-              {% endif %}
+            {% endif %}
+            {% if not subsection_path.endswith('/') %}
+              <!-- add '/' to end of path to match all of the other urls -->
+              {% set subsection_path = subsection_path + '/' %}
             {% endif %}
             {% set image_path = '/images/index-pages/' + subsection_path[:-1] + '.png' %}
             <div class="card">

--- a/mkdocs-cn/material-overrides/subsection-index-page.html
+++ b/mkdocs-cn/material-overrides/subsection-index-page.html
@@ -20,6 +20,20 @@
             {% else %}
               {% set subsection_path = nav_item.url %}
             {% endif %}
+            <!-- for pages that point to sections within other pages -->
+            {% if '#' in subsection_path %} 
+              <!-- remove the section from the path -->
+              {% set subsection_path = subsection_path.split('#')[0][1:] %}
+            {% endif %}
+            <!-- for pages that point to other directories -->
+            {% if page.url not in subsection_path %}
+              <!-- remove initial '/' from relative path -->
+              {% set subsection_path = subsection_path[1:] %}
+              {% if not subsection_path.endswith('/') %}
+                <!-- add '/' to end of path to match all of the other urls -->
+                {% set subsection_path = subsection_path + '/' %}
+              {% endif %}
+            {% endif %}
             {% set image_path = '/images/index-pages/' + subsection_path[:-1] + '.png' %}
             <div class="card">
               <a href="{{ subsection_path|replace(page.url, '') }}">

--- a/mkdocs-cn/material-overrides/subsection-index-page.html
+++ b/mkdocs-cn/material-overrides/subsection-index-page.html
@@ -1,0 +1,64 @@
+{% extends "main.html" %}
+
+{% block content %}
+
+{% macro find_active_page(element) %}
+
+  {% for nav_item in element %}
+    {% if nav_item.active %}
+      {% if nav_item.is_section %}
+        <!-- continue to find active page -->
+        {{ find_active_page(nav_item.children) }}
+      {% else %}
+        <!-- render subsection content -->
+        {% if nav_item.is_page %}
+          <h1 class="subsection-title">{{ nav_item.parent.title }}</h1>
+          <div class="subsection-wrapper">
+          {% for nav_item in element[1:] %}
+            {% if nav_item.is_section %}
+              {% set subsection_path = nav_item.children[0].url %}
+            {% else %}
+              {% set subsection_path = nav_item.url %}
+            {% endif %}
+            {% set image_path = '/images/index-pages/' + subsection_path[:-1] + '.png' %}
+            <div class="card">
+              <a href="{{ subsection_path|replace(page.url, '') }}">
+                <h2 class="title">{{ nav_item.title }}</h2> 
+                <img class="icon" src="{{ image_path }}">
+              </a>    
+            </div>
+          {% endfor %}
+          </div>
+        {% endif %}
+      {% endif %}
+    {% endif %}
+  {% endfor %}
+
+  {% set most_nested_active_element = None %}
+  {% if element.active == True %}
+    {{ element }}
+    {% set most_nested_active_element = element %}
+  {% endif %}
+
+  {% if element.active and element.children %}
+    Hei
+    {% for child in element.children %}
+      Here
+      {% set nested_active_element = find_active_page(child) %}
+      {% if nested_active_element != none %}
+        {% set most_nested_active_element = nested_active_element %}
+      {% endif %}
+    {% endfor %}
+  {% endif %}
+{% endmacro %}
+
+<div class="subsection-page">
+    {% if nav|length>1 %}
+      {% for nav_item in nav %}
+        {% if nav_item.is_section and nav_item.active %}
+          {{ find_active_page(nav_item.children) }}
+        {% endif %}
+      {% endfor %}
+    {% endif %}
+</div>
+{% endblock %}

--- a/mkdocs-cn/mkdocs.yml
+++ b/mkdocs-cn/mkdocs.yml
@@ -9,7 +9,6 @@ docs_dir: moonbeam-docs-cn
   - 'js/errorModal.js'
   - 'js/networkModal.js'
   - 'js/handleLanguageChange.js'
-  - 'js/renderSubsections.js'
   - 'js/fixCreatedDate.js'
   - 'js/externalLinkModal.js'
 'theme':

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,7 +9,6 @@
     - 'js/errorModal.js'
     - 'js/networkModal.js'
     - 'js/handleLanguageChange.js'
-    - 'js/renderSubsections.js'
     - 'js/fixCreatedDate.js'
     - 'js/externalLinkModal.js'
 'theme':


### PR DESCRIPTION
This PR adds two templates for the index pages:

1) For main index pages i.e., Builders, Node Operators, Learn, etc.
2) For all other ("subsection") index pages

The main differences being that the main index pages include disclaimers that the subsection index pages don't and the subsection index pages contain logic to dive deeper to generate index pages for nested directories

It also removes the old script for rendering subsections.

Goes with PRs: 
- EN: https://github.com/PureStake/moonbeam-docs/pull/606
- CN: https://github.com/PureStake/moonbeam-docs-cn/pull/262
