### PR TITLE
edit logic for getting link to pages vs icon hrefs

### DIFF
--- a/material-overrides/subsection-index-page.html
+++ b/material-overrides/subsection-index-page.html
@@ -38,7 +38,7 @@
             <div class="card">
               <a href="{{ subsection_path|replace(page.url, '') }}">
                 <h2 class="title">{{ nav_item.title }}</h2> 
-                <img class="icon" src="{{ image_path }}">
+                <img class="icon" alt="{{ nav_item.title }}" src="{{ image_path }}">
               </a>    
             </div>
           {% endfor %}

--- a/material-overrides/subsection-index-page.html
+++ b/material-overrides/subsection-index-page.html
@@ -19,20 +19,22 @@
             {% else %}
               {% set subsection_path = nav_item.url %}
             {% endif %}
-            <!-- for pages that point to sections within other pages -->
-            {% if '#' in subsection_path %} 
-              <!-- remove the section from the path -->
-              {% set subsection_path = subsection_path.split('#')[0] %}
-            {% endif %}
-            {% if subsection_path.startswith('/') %}
+            <!-- make modifications necessary for section index page icons -->
+            {% set image_path = subsection_path %}
+            {% if image_path.startswith('/') %}
               <!-- remove initial '/' from relative path -->
-              {% set subsection_path = subsection_path[1:] %}
+              {% set image_path = image_path[1:] %}
             {% endif %}
-            {% if not subsection_path.endswith('/') %}
+            {% if '#' in image_path %} 
+              <!-- for pages that point to sections within other pages
+                remove the section from the path -->
+              {% set image_path = image_path.split('#')[0] %}
+            {% endif %}
+            {% if not image_path.endswith('/') %}
               <!-- add '/' to end of path to match all of the other urls -->
-              {% set subsection_path = subsection_path + '/' %}
+              {% set image_path = image_path + '/' %}
             {% endif %}
-            {% set image_path = '/images/index-pages/' + subsection_path[:-1] + '.png' %}
+            {% set image_path = '/images/index-pages/' + image_path[:-1] + '.png' %}
             <div class="card">
               <a href="{{ subsection_path|replace(page.url, '') }}">
                 <h2 class="title">{{ nav_item.title }}</h2> 

--- a/mkdocs-cn/material-overrides/subsection-index-page.html
+++ b/mkdocs-cn/material-overrides/subsection-index-page.html
@@ -38,7 +38,7 @@
             <div class="card">
               <a href="{{ subsection_path|replace(page.url, '') }}">
                 <h2 class="title">{{ nav_item.title }}</h2> 
-                <img class="icon" src="{{ image_path }}">
+                <img class="icon" alt="{{ nav_item.title }}" src="{{ image_path }}">
               </a>    
             </div>
           {% endfor %}

--- a/mkdocs-cn/material-overrides/subsection-index-page.html
+++ b/mkdocs-cn/material-overrides/subsection-index-page.html
@@ -19,20 +19,22 @@
             {% else %}
               {% set subsection_path = nav_item.url %}
             {% endif %}
-            <!-- for pages that point to sections within other pages -->
-            {% if '#' in subsection_path %} 
-              <!-- remove the section from the path -->
-              {% set subsection_path = subsection_path.split('#')[0] %}
-            {% endif %}
-            {% if subsection_path.startswith('/') %}
+            <!-- make modifications necessary for section index page icons -->
+            {% set image_path = subsection_path %}
+            {% if image_path.startswith('/') %}
               <!-- remove initial '/' from relative path -->
-              {% set subsection_path = subsection_path[1:] %}
+              {% set image_path = image_path[1:] %}
             {% endif %}
-            {% if not subsection_path.endswith('/') %}
+            {% if '#' in image_path %} 
+              <!-- for pages that point to sections within other pages
+                remove the section from the path -->
+              {% set image_path = image_path.split('#')[0] %}
+            {% endif %}
+            {% if not image_path.endswith('/') %}
               <!-- add '/' to end of path to match all of the other urls -->
-              {% set subsection_path = subsection_path + '/' %}
+              {% set image_path = image_path + '/' %}
             {% endif %}
-            {% set image_path = '/images/index-pages/' + subsection_path[:-1] + '.png' %}
+            {% set image_path = '/images/index-pages/' + image_path[:-1] + '.png' %}
             <div class="card">
               <a href="{{ subsection_path|replace(page.url, '') }}">
                 <h2 class="title">{{ nav_item.title }}</h2> 


### PR DESCRIPTION
Update logic for editing the links to the subsection's pages vs the href links to the icons.

For example, take a look at this URL: `/builders/interoperability/xcm/xcm-transactor/#xcmtransactor-precompile`
- the `image_path` was correct and was rendered as `/images/index-pages/builders/interoperability/xcm/xcm-transactor.png`
- the `subsection_path` was changed to `builders/interoperability/xcm/xcm-transactor/`, which means the path wasn't relative and the link to the `#xcmtransactor-precompile` section was lost and so the final path ended up being `/builders/pallets-precompiles/precompiles/builders/interoperability/xcm/xcm-transactor/`

This PR changes it so that the `image_path`s are updated only and the `subsection_path`s are not unnecessarily modified