### PR TITLE
add support for ga4

### DIFF
--- a/material-overrides/partials/integrations/analytics/google.html
+++ b/material-overrides/partials/integrations/analytics/google.html
@@ -1,0 +1,186 @@
+<!--
+  Copyright (c) 2016-2023 Martin Donath <martin.donath@squidfunk.com>
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to
+  deal in the Software without restriction, including without limitation the
+  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+  sell copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+  IN THE SOFTWARE.
+-->
+
+<!-- Determine analytics property -->
+{% if config.extra.analytics %}
+  {% set property = config.extra.analytics.property | d("", true) %}
+{% endif %}
+
+<!-- TODO: once we phase out UA we can delete this file entirely, but to support
+both UA and GA4 we need to manually add the GA4 tag here since material-mkdocs 
+defaults to using one or the other -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-5ZBERCXWC3"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-5ZBERCXWC3');
+</script>
+
+<!-- Google Analytics 4 (G-XXXXXXXXXX) -->
+{% if property.startswith("G-") %}
+  <script id="__analytics">
+    function __md_analytics() {
+      window.dataLayer = window.dataLayer || []
+      function gtag() { dataLayer.push(arguments) }
+
+      /* Set up integration and send page view */
+      gtag("js", new Date())
+      gtag("config", "{{ property }}")
+
+      /* Register event handlers after documented loaded */
+      document.addEventListener("DOMContentLoaded", function() {
+
+        /* Set up search tracking */
+        if (document.forms.search) {
+          var query = document.forms.search.query
+          query.addEventListener("blur", function() {
+            if (this.value)
+              gtag("event", "search", { search_term: this.value })
+          })
+        }
+
+        /* Set up feedback, i.e. "Was this page helpful?" */
+        document$.subscribe(function() {
+          var feedback = document.forms.feedback
+          if (typeof feedback === "undefined")
+            return
+
+          /* Send feedback to Google Analytics */
+          for (var button of feedback.querySelectorAll("[type=submit]")) {
+            button.addEventListener("click", function(ev) {
+              ev.preventDefault()
+
+              /* Retrieve and send data */
+              var page = document.location.pathname
+              var data = this.getAttribute("data-md-value")
+              gtag("event", "feedback", { page, data })
+
+              /* Disable form and show note, if given */
+              feedback.firstElementChild.disabled = true
+              var note = feedback.querySelector(
+                ".md-feedback__note [data-md-value='" + data + "']"
+              )
+              if (note)
+                note.hidden = false
+            })
+
+            /* Show feedback */
+            feedback.hidden = false
+          }
+        })
+
+        /* Send page view on location change */
+        location$.subscribe(function(url) {
+          gtag("config", "{{ property }}", {
+            page_path: url.pathname
+          })
+        })
+      })
+
+      /* Create script tag */
+      var script = document.createElement("script")
+      script.async = true
+      script.src = "https://www.googletagmanager.com/gtag/js?id={{ property }}"
+
+      /* Inject script tag */
+      var container = document.getElementById("__analytics")
+      container.insertAdjacentElement("afterEnd", script)
+    }
+  </script>
+
+<!-- Universal Analytics (UA-XXXXXXXX-X) -->
+{% elif property.startswith("UA-") %}
+  <script id="__analytics">
+    function __md_analytics() {
+      window.ga = window.ga || function() {
+        (ga.q = ga.q || []).push(arguments)
+      }
+      ga.l = +new Date()
+
+      /* Set up integration and send page view */
+      ga("create", "{{ property }}", "auto")
+      ga("set", "anonymizeIp", true)
+      ga("send", "pageview")
+
+      /* Register event handlers after documented loaded */
+      document.addEventListener("DOMContentLoaded", function() {
+
+        /* Set up search tracking */
+        if (document.forms.search) {
+          var query = document.forms.search.query
+          query.addEventListener("blur", function() {
+            if (this.value) {
+              var page = document.location.pathname;
+              ga("send", "pageview", page + "?q=" + this.value)
+            }
+          })
+        }
+
+        /* Set up feedback, i.e. "Was this page helpful?" */
+        document$.subscribe(function() {
+          var feedback = document.forms.feedback
+          if (typeof feedback === "undefined")
+            return
+
+          /* Send feedback to Google Analytics */
+          for (var button of feedback.querySelectorAll("[type=submit]")) {
+            button.addEventListener("click", function(ev) {
+              ev.preventDefault()
+
+              /* Retrieve and send data */
+              var page = document.location.pathname
+              var data = this.getAttribute("data-md-value")
+              ga("send", "event", "feedback", "click", page, data)
+
+              /* Disable form and show note, if given */
+              feedback.firstElementChild.disabled = true
+              var note = feedback.querySelector(
+                ".md-feedback__note [data-md-value='" + data + "']"
+              )
+              if (note)
+                note.hidden = false
+            })
+
+            /* Show feedback */
+            feedback.hidden = false
+          }
+        })
+
+        /* Send page view on location change */
+        location$.subscribe(function(url) {
+          ga("send", "pageview", url.pathname)
+        })
+      })
+
+      /* Create script tag */
+      var script = document.createElement("script")
+      script.async = true
+      script.src = "https://www.google-analytics.com/analytics.js"
+
+      /* Inject script tag */
+      var container = document.getElementById("__analytics")
+      container.insertAdjacentElement("afterEnd", script)
+    }
+  </script>
+{% endif %}

--- a/mkdocs-cn/material-overrides/partials/integrations/analytics/google.html
+++ b/mkdocs-cn/material-overrides/partials/integrations/analytics/google.html
@@ -1,0 +1,186 @@
+<!--
+  Copyright (c) 2016-2023 Martin Donath <martin.donath@squidfunk.com>
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to
+  deal in the Software without restriction, including without limitation the
+  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+  sell copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+  IN THE SOFTWARE.
+-->
+
+<!-- Determine analytics property -->
+{% if config.extra.analytics %}
+  {% set property = config.extra.analytics.property | d("", true) %}
+{% endif %}
+
+<!-- TODO: once we phase out UA we can delete this file entirely, but to support
+both UA and GA4 we need to manually add the GA4 tag here since material-mkdocs 
+defaults to using one or the other -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-5ZBERCXWC3"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-5ZBERCXWC3');
+</script>
+
+<!-- Google Analytics 4 (G-XXXXXXXXXX) -->
+{% if property.startswith("G-") %}
+  <script id="__analytics">
+    function __md_analytics() {
+      window.dataLayer = window.dataLayer || []
+      function gtag() { dataLayer.push(arguments) }
+
+      /* Set up integration and send page view */
+      gtag("js", new Date())
+      gtag("config", "{{ property }}")
+
+      /* Register event handlers after documented loaded */
+      document.addEventListener("DOMContentLoaded", function() {
+
+        /* Set up search tracking */
+        if (document.forms.search) {
+          var query = document.forms.search.query
+          query.addEventListener("blur", function() {
+            if (this.value)
+              gtag("event", "search", { search_term: this.value })
+          })
+        }
+
+        /* Set up feedback, i.e. "Was this page helpful?" */
+        document$.subscribe(function() {
+          var feedback = document.forms.feedback
+          if (typeof feedback === "undefined")
+            return
+
+          /* Send feedback to Google Analytics */
+          for (var button of feedback.querySelectorAll("[type=submit]")) {
+            button.addEventListener("click", function(ev) {
+              ev.preventDefault()
+
+              /* Retrieve and send data */
+              var page = document.location.pathname
+              var data = this.getAttribute("data-md-value")
+              gtag("event", "feedback", { page, data })
+
+              /* Disable form and show note, if given */
+              feedback.firstElementChild.disabled = true
+              var note = feedback.querySelector(
+                ".md-feedback__note [data-md-value='" + data + "']"
+              )
+              if (note)
+                note.hidden = false
+            })
+
+            /* Show feedback */
+            feedback.hidden = false
+          }
+        })
+
+        /* Send page view on location change */
+        location$.subscribe(function(url) {
+          gtag("config", "{{ property }}", {
+            page_path: url.pathname
+          })
+        })
+      })
+
+      /* Create script tag */
+      var script = document.createElement("script")
+      script.async = true
+      script.src = "https://www.googletagmanager.com/gtag/js?id={{ property }}"
+
+      /* Inject script tag */
+      var container = document.getElementById("__analytics")
+      container.insertAdjacentElement("afterEnd", script)
+    }
+  </script>
+
+<!-- Universal Analytics (UA-XXXXXXXX-X) -->
+{% elif property.startswith("UA-") %}
+  <script id="__analytics">
+    function __md_analytics() {
+      window.ga = window.ga || function() {
+        (ga.q = ga.q || []).push(arguments)
+      }
+      ga.l = +new Date()
+
+      /* Set up integration and send page view */
+      ga("create", "{{ property }}", "auto")
+      ga("set", "anonymizeIp", true)
+      ga("send", "pageview")
+
+      /* Register event handlers after documented loaded */
+      document.addEventListener("DOMContentLoaded", function() {
+
+        /* Set up search tracking */
+        if (document.forms.search) {
+          var query = document.forms.search.query
+          query.addEventListener("blur", function() {
+            if (this.value) {
+              var page = document.location.pathname;
+              ga("send", "pageview", page + "?q=" + this.value)
+            }
+          })
+        }
+
+        /* Set up feedback, i.e. "Was this page helpful?" */
+        document$.subscribe(function() {
+          var feedback = document.forms.feedback
+          if (typeof feedback === "undefined")
+            return
+
+          /* Send feedback to Google Analytics */
+          for (var button of feedback.querySelectorAll("[type=submit]")) {
+            button.addEventListener("click", function(ev) {
+              ev.preventDefault()
+
+              /* Retrieve and send data */
+              var page = document.location.pathname
+              var data = this.getAttribute("data-md-value")
+              ga("send", "event", "feedback", "click", page, data)
+
+              /* Disable form and show note, if given */
+              feedback.firstElementChild.disabled = true
+              var note = feedback.querySelector(
+                ".md-feedback__note [data-md-value='" + data + "']"
+              )
+              if (note)
+                note.hidden = false
+            })
+
+            /* Show feedback */
+            feedback.hidden = false
+          }
+        })
+
+        /* Send page view on location change */
+        location$.subscribe(function(url) {
+          ga("send", "pageview", url.pathname)
+        })
+      })
+
+      /* Create script tag */
+      var script = document.createElement("script")
+      script.async = true
+      script.src = "https://www.google-analytics.com/analytics.js"
+
+      /* Inject script tag */
+      var container = document.getElementById("__analytics")
+      container.insertAdjacentElement("afterEnd", script)
+    }
+  </script>
+{% endif %}

--- a/mkdocs-cn/mkdocs.yml
+++ b/mkdocs-cn/mkdocs.yml
@@ -260,7 +260,7 @@ docs_dir: moonbeam-docs-cn
       'name': 'GitHub'
   'analytics':
     'provider': 'google'
-    'property': 'UA-135971059-6'
+    'property': 'UA-135971059-6'  # TODO: remove the google.html override once we update this to GA4
     'feedback':
         'title': '此页面是否有帮助?'
         'ratings':

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -528,7 +528,7 @@
           'name': 'GitHub'
     'analytics':
         'provider': 'google'
-        'property': 'UA-135971059-6'
+        'property': 'UA-135971059-6' # TODO: remove the google.html override once we update this to GA4
         'feedback':
             'title': 'Was this page helpful?'
             'ratings':


### PR DESCRIPTION
This PR adds a ga4 tag for google analytics. Per Katie, it will eventually replace the UA tag, but it shouldn't be deleted yet. Since material-mkdocs is designed so that one or the other is used, I had to customize the `google.html` file to manually add in the ga4 tag.

Once we replace the UA tag for good, we can delete the google.html file as we can use the default behavior again, so left a couple `TODO`s as a reminder